### PR TITLE
Fix redirect test

### DIFF
--- a/test/actions/employeesActions_spec.js
+++ b/test/actions/employeesActions_spec.js
@@ -2,12 +2,8 @@ import {expect} from 'chai'
 import nock from 'nock'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import { routerMiddleware } from 'react-router-redux'
-import historyType from '../../src/history'
-import multi from 'redux-multi'
 
-
-const middlewares = [ multi, thunk, routerMiddleware(historyType)]
+const middlewares = [ thunk ]
 const mockStore = configureMockStore(middlewares)
 
 import { loadAllEmployees, deleteEmployee, addNewEmployee, editEmployee, editAndRedirectEmployee } from '../../src/AC/employees'
@@ -88,23 +84,26 @@ describe('async actions', () => {
 				"email": "Rob@test.com"
 			}
 
+		const routerPayload = {
+			method: 'push',
+			args: ['/employees/'+data.id]
+		}
+
 		nock('http://localhost:8080')
 			.put('/api/employees/' + data.id, data)
 			.reply(200, [data] )
 
 		const expectedActions = [
 			{type: EDIT_EMPLOYEE + START},
-			{type: EDIT_EMPLOYEE + SUCCESS, response: [data]}
-
+			{type: EDIT_EMPLOYEE + SUCCESS, response: [data]},
+			{type: '@@router/CALL_HISTORY_METHOD', payload: routerPayload}
 		]
 
 		const store = mockStore([])
 
 		return store.dispatch(editAndRedirectEmployee(data))
 			.then(() => {
-				console.log(store.getActions())
 				expect(store.getActions()).to.deep.equal(expectedActions)
-				//expect(store).toContainLocation({pathname: '/employees/' + data.id})
 			})
 	})
 })


### PR DESCRIPTION
Для тестов нет необходимости подключать все middlewares, и более того - один из них нам мешал, так как пытался вызвать метод removeItem объекта "window.sessionStorage". А как известно, у нас в момент запуска используется среда node, и там нет объекта window.

Тем не менее, мы в файле setup.js эмулируем объект window. Но у нас все равно еще нет sessionStorage.

P.S. я на всякий случай попробовал сэмулировать sessionStorage, но все равно тест не проходил => здесь надо исследовать глубже.

**Итого**: для тестирования асинхронных actions нам нужен всего один middleware - redux-thunk. 